### PR TITLE
AJ-1938 Small fixes for cost notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,12 @@ There should be one or more cells near the top of the notebook that:
 
 from anvil_lite_cost_analysis import alca
 ```
+
+If you are updating this repo and want to use your branch from within a Jupyter Notebook, you'll need to checkout your branch from a terminal in Jupyter:
+1. File -> New Launcher
+2. Select Terminal
+3. In the terminal:
+ ```
+ cd anvil_lite_cost_analysis
+ git checkout <your-branch>
+ ```

--- a/alca/azure.py
+++ b/alca/azure.py
@@ -107,4 +107,4 @@ def get_latest_blobmanifest(sas_token, config: Config):
         key = lambda m: m['properties']['lastModified'],
         reverse = True
     )
-    return sorted_manifest_output[0]['name']
+    return sorted_manifest_output[0]['name'] if sorted_manifest_output else None

--- a/alca/util.py
+++ b/alca/util.py
@@ -16,7 +16,6 @@ Config = namedtuple('Config', [
     'target_mrgs',
     'container_name',
     'container_id',
-    'blob_inventory_name',
     'blob_inventory_prefix',
     'cost_management_storage_account',
     'cost_management_storage_container',

--- a/anvil_lite_cost_analysis.ipynb
+++ b/anvil_lite_cost_analysis.ipynb
@@ -68,7 +68,6 @@
     "    ],\n",
     "    container_name = os.environ['WORKSPACE_STORAGE_CONTAINER_URL'].split('/')[-1],\n",
     "    container_id = os.environ['WORKSPACE_STORAGE_CONTAINER_ID'],\n",
-    "    blob_inventory_name = \"AnvilLite_Azure_blob_inventory\",\n",
     "    blob_inventory_prefix = \"2024\",\n",
     "    cost_management_storage_account = \"costandstorageexports\",\n",
     "    cost_management_storage_container = \"costanalysis\",\n",


### PR DESCRIPTION
Just some things I noticed while working on [AJ-1938]( https://broadworkbench.atlassian.net/browse/AJ-1938):
- removes an unused variable
- deals gracefully with an empty blob inventory.  I don't expect this to happen in practice, if we've set up the exports ahead of time, but seeing that it's empty is probably better than an ugly error just in case
- updates the README for developers

[AJ-1938]: https://broadworkbench.atlassian.net/browse/AJ-1938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ